### PR TITLE
Value Help for Nodejs bookshop sample

### DIFF
--- a/ams-cap-nodejs-bookshop/README.md
+++ b/ams-cap-nodejs-bookshop/README.md
@@ -80,6 +80,36 @@ To deploy with *sqlite*, you must copy the [db.sqlite](db.sqlite) file to `gen/s
 
 Please note that `cds add mta` creates a `mta.yaml` that contains a `before-all` command that runs `cds build --production`. This deletes and re-creates the `gen` folder after you manually copied the file. In that case, you should add another command behind it such as `cp db.sqlite gen/srv/db.sqlite` instead of manually copying.
 
+### (Optional) Configure Value Help in mta.yaml
+To add value help to your application, replace the section for ams-cap-nodejs-bookshop-auth with this: 
+```yaml
+resources:
+  - name: ams-cap-nodejs-bookshop-auth
+    type: org.cloudfoundry.managed-service
+    parameters:
+      service: identity
+      service-name: ams-cap-nodejs-bookshop-auth
+      service-plan: application
+      config:
+        display-name: ams-cap-nodejs-bookshop-marie
+        provided-apis:
+          - name: AMS_ValueHelp
+            description: Value Help Callback from AMS
+            type: public
+        authorization:
+          enabled: true
+          value-help-url: ~{srv-api/srv-cert-url}/odata/v4/ams-value-help/
+          value-help-api-name: AMS_ValueHelp
+        oauth2-configuration:
+          redirect-uris:
+            - ~{app-api/app-protocol}://~{app-api/app-uri}/login/callback
+          post-logout-redirect-uris:
+            - ~{app-api/app-protocol}://~{app-api/app-uri}/*/logout.html
+    requires:
+      - name: srv-api
+      - name: app-api
+```
+
 ### Deployment
 
 :warning: Please make sure to use `@sap/cds-dk` version `>= 8.7.3` to get correct deployment configurations for *ams*/*ias*. Remember to update your global npm installation of `@sap/cds-dk` if you have one as it has priority over the version specified in *node_modules*. Use `cds version -i` to check.

--- a/ams-cap-nodejs-bookshop/ams/dcl/schema.dcl
+++ b/ams-cap-nodejs-bookshop/ams/dcl/schema.dcl
@@ -5,6 +5,11 @@
 
 SCHEMA {
 	description: String,
+	@valueHelp: { 
+		path: 'Genres',
+		valueField: 'name',
+		labelField: 'name'
+	}
 	genre: String,
 	just: {
 		for: {

--- a/ams-cap-nodejs-bookshop/srv/vh-service.cds
+++ b/ams-cap-nodejs-bookshop/srv/vh-service.cds
@@ -1,0 +1,6 @@
+using { sap.capire.bookshop as my }  from '../db/schema';
+
+service AmsValueHelpService @(requires: 'Reader') {
+    @cds.localized: false
+    entity Genres as projection on my.Genres;
+}


### PR DESCRIPTION
I added value help for the genre attribute in the cap bookshop sample. Therefore I added the vh-service.cds and the added the value help annotation in the schema.dcl. Changes that need to be done in the mta.yaml file are described in the README.md file.