### PR TITLE
fix AMS_ValueHelp policy

### DIFF
--- a/ams-cap-nodejs-bookshop/ams/dcl/internal/apiPolicies.dcl
+++ b/ams-cap-nodejs-bookshop/ams/dcl/internal/apiPolicies.dcl
@@ -1,5 +1,5 @@
 INTERNAL Policy AMS_ValueHelp {
-    USE cap.Reader;
+    USE cap.admin;
 }
 
 INTERNAL Policy ReadCatalog {


### PR DESCRIPTION
Grant `admin` instead of `Reader` for AMS_ValueHelp API Permission Group.